### PR TITLE
Replace deprecated pynvml with nvidia-ml-py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "numpy>=1.21.0",           # Basic numpy operations
     "matplotlib>=3.5.0",       # Profiling plots and visualizations
     "psutil>=5.9.0",           # System resource monitoring
+    "nvidia-ml-py>=11.5.0",    # GPU monitoring and profiling
     "tqdm>=4.64.0",            # Progress bars for profiling
 ]
 


### PR DESCRIPTION
## Summary

- Add `nvidia-ml-py>=11.5.0` as a core dependency in `pyproject.toml`
- The profiling module (`src/hpc_inference/utils/profiling.py`) imports `pynvml` but it was never declared as a dependency on `main`
- The third-party `pynvml` PyPI package is deprecated — it's now a shim that installs `nvidia-ml-py` and emits a `FutureWarning` on every import
- Using `nvidia-ml-py` directly provides the same `import pynvml` API with no warnings

## Note for open PRs

PR #16 (`feature/detection`) added `pynvml>=11.5.0` to dependencies. After this PR merges, #16 should rebase and update its dependency to `nvidia-ml-py>=11.5.0` instead.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)